### PR TITLE
Disable autocomplete for non-relevant input fields

### DIFF
--- a/client/src/views/AdminView.vue
+++ b/client/src/views/AdminView.vue
@@ -230,6 +230,7 @@ export default {
                                 id="delShortInput"
                                 v-model="delShortId"
                                 placeholder="Short ID"
+                                autocomplete="off"
                             />
                             <button type="submit" class="btn btn-danger">
                                 Delete
@@ -260,6 +261,7 @@ export default {
                                 id="createUserDisplayNameInput"
                                 v-model="createUserDisplayName"
                                 placeholder="Display name"
+                                autocomplete="off"
                             />
                         </p>
                         <div class="input-group">
@@ -269,6 +271,7 @@ export default {
                                 id="createUserPINInput"
                                 v-model="createUserPIN"
                                 placeholder="Unique PIN"
+                                autocomplete="off"
                             />
                             <button type="submit" class="btn btn-primary">
                                 Create
@@ -294,6 +297,7 @@ export default {
                                 id="delUserInput"
                                 v-model="delUserId"
                                 placeholder="User ID"
+                                autocomplete="off"
                             />
                             <button type="submit" class="btn btn-danger">
                                 Delete

--- a/client/src/views/HomeView.vue
+++ b/client/src/views/HomeView.vue
@@ -108,6 +108,7 @@ export default {
                                 :readonly="showingResult"
                                 placeholder="Paste the long URL here ..."
                                 autofocus
+                                autocomplete="off"
                             />
                             <input
                                 v-if="authReq"


### PR DESCRIPTION
Fix some browsers trying to insert the authentication credentials using autocomplete into wrong input fields, such as the long URL or user creation/deletion in admin panel.